### PR TITLE
修复连接失败问题

### DIFF
--- a/api.go
+++ b/api.go
@@ -80,7 +80,7 @@ func (c *Connection) apiOpsToEndpoint(apiOps apiOps, account string) string {
 	case api_QUERY:
 		return "/accounts/" + account + "/d1/database/" + c.databaseId + "/raw"
 	case API_TOKEN:
-		return "/user/tokens/verify"
+		return "/accounts/" + account + "/tokens/verify"
 	default:
 		return ""
 	}


### PR DESCRIPTION
作者你好，我在使用你的库连接d1时出现了问题，出现权限相关的报错
在我断点+调试了后发现似乎你使用了v3的api，这个api在v4中更换了使用方式，而非仅仅更改了v3字符串到v4，我做了修改使程序正常工作。
我运行了单元测试，代码应该没有问题
---
以下是官网的v3api
<img width="1142" alt="image" src="https://github.com/user-attachments/assets/cf4b6221-cccd-4fbc-a10a-1988c4cd63cf" />
以下是官网的v4api
<img width="1152" alt="image" src="https://github.com/user-attachments/assets/2f313103-57ef-4346-a7ed-f31a75325e6b" />
